### PR TITLE
Compatibility with ggplot2

### DIFF
--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,7 +1,12 @@
 test_that("Function returns a ggplot object", {
 
+  get_labs <- function(x) x$labels
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    get_labs <- ggplot2::get_labs
+  }
+
   has_no_legend_labels <- function(plot) {
-    labels <- plot$labels
+    labels <- get_labs(plot)
     is.null(labels$fill) && is.null(labels$colour)
   }
 
@@ -53,7 +58,7 @@ test_that("Function returns a ggplot object", {
 
   expect_false(has_no_legend_labels(p_box))
   expect_true(p_box$theme$axis.title.y$size == 10)
-  expect_true(p_box$labels$label1 == "min")
+  expect_true(get_labs(p_box)$label1 == "min")
 
   expect_no_error(
     p <- scatterPlot(
@@ -71,9 +76,10 @@ test_that("Function returns a ggplot object", {
     ) +
       themeVisOmop()
   )
-  expect_true(p$labels$label1 == "age_group")
-  expect_true(p$labels$label2 == "mean")
-  expect_true(p$labels$label3 == "cohort_name")
+  labels <- get_labs(p)
+  expect_true(labels$label1 == "age_group")
+  expect_true(labels$label2 == "mean")
+  expect_true(labels$label3 == "cohort_name")
 
   p <- scatterPlot(
     result,
@@ -103,7 +109,7 @@ test_that("Function returns a ggplot object", {
 
   expect_no_error(p_bar)
   expect_true(has_no_legend_labels(p_bar))
-  expect_true(p_bar$labels$label1 == "cohort_name")
+  expect_true(get_labs(p_bar)$label1 == "cohort_name")
 
   p_bar <- barPlot(
     result = result,


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the visOmopResults package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun
